### PR TITLE
Improve README, man page, and Texinfo docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,74 @@
 # json-view
 
-A small terminal JSON viewer using [ncurses](https://invisible-island.net/ncurses/) and [nlohmann/json](https://github.com/nlohmann/json).
+`json-view` is a small, fast JSON viewer for the terminal.  It renders
+documents as an interactive tree using
+[ncurses](https://invisible-island.net/ncurses/) and the
+[nlohmann/json](https://github.com/nlohmann/json) library.  The viewer is
+useful for quickly inspecting large files directly from the command line.
 
-## Build
+## Features
 
-This project uses [CMake](https://cmake.org) and requires a C++20 compiler and the wide-character ncurses library.
+* Expand and collapse nodes with the arrow keys or the mouse.
+* Search keys or values and jump between matches.
+* Open multiple files or read JSON from standard input.
+* Optional mouse support for selection and expansion.
+
+## Requirements
+
+* A C++20 compliant compiler
+* [CMake](https://cmake.org) 3.20 or newer
+* The wide-character `ncursesw` library
+* [nlohmann/json](https://github.com/nlohmann/json) (bundled)
+
+## Building
 
 ```sh
 cmake -S . -B build
 cmake --build build
 ```
 
-## Install
+## Installation
 
-To install the `json-view` binary into `/usr/local/bin` (the default prefix on macOS and most Linux systems):
+Install the binary (defaults to `/usr/local`):
 
 ```sh
 sudo cmake --install build
 ```
 
-You can choose a different prefix by setting `-DCMAKE_INSTALL_PREFIX=/usr` when configuring CMake.
+The install prefix can be changed at configure time using
+`-DCMAKE_INSTALL_PREFIX=/usr`.
 
 ## Usage
 
-```
+```sh
 json-view path/to/file.json
+# or read from standard input
+cat file.json | json-view
 ```
 
-The viewer uses the arrow keys to navigate and `q` to quit.
+If no file argument is supplied `json-view` will read a single JSON document
+from standard input.  The interface uses the arrow keys to navigate and `q` to
+quit.
 
-## Features
+### Key bindings
 
-*   Navigate JSON files using arrow keys.
-*   Collapsible nodes.
-*   Mouse support for navigation.
+* `↑/↓` – move the selection
+* `→/←` – expand or collapse nodes
+* `s` – search keys, `S` – search values
+* `n`/`N` – next/previous search match
+* `h` – show a help screen
+* `q` – quit the viewer
+
+## Documentation
+
+After installation the command line help is available through the manual and
+Texinfo pages:
+
+```sh
+man json-view
+info json-view
+```
+
+## License
+
+`json-view` is released under the terms of the [MIT License](LICENSE).

--- a/doc/json-view.1
+++ b/doc/json-view.1
@@ -1,23 +1,50 @@
 
-.TH "JSON-VIEW" "1" "September 2025" "json-view 1.0" "User Commands"
-.SH "NAME"
-json-view - a small terminal JSON viewer
-.SH "SYNOPSIS"
+.TH "JSON-VIEW" "1" "May 2025" "json-view 1.0" "User Commands"
+.SH NAME
+json-view \- terminal JSON viewer
+.SH SYNOPSIS
 .B json-view
-.I file.json
-.SH "DESCRIPTION"
+.RI [ FILE\ .\|.\|. ]
+.SH DESCRIPTION
 .B json-view
-is a small terminal JSON viewer using ncurses. It allows navigating JSON files with arrow keys.
-.SH "OPTIONS"
-This tool currently does not support any command-line options.
-.SH "USAGE"
-To view a JSON file, pass the path to the file as an argument:
-.PP
+displays JSON data in a navigable tree using the
+.BR ncurses (3x)
+library.  If no
+.I FILE
+is provided the program reads a single document from standard input.
+.SH OPTIONS
+.TP
+.B -h , --help
+Show usage information.
+.TP
+.B --version
+Display version information and exit.
+.SH KEYS
+The interface responds to the following keys:
+.TP
+.B Up/Down
+Move the selection.
+.TP
+.B Left/Right
+Collapse or expand the current node.
+.TP
+.B s / S
+Search keys or values.
+.TP
+.B n / N
+Jump to the next or previous search match.
+.TP
+.B q
+Quit the program.
+.SH SEE ALSO
+The Texinfo manual for
 .B json-view
-.I path/to/file.json
-.PP
-The viewer uses the arrow keys to navigate and 'q' to quit.
-.SH "BUGS"
-No known bugs.
-.SH "AUTHOR"
-John Doe <johndoe@example.com>
+may be viewed with
+.BR info (1):
+.RS
+.nf
+info json-view
+.fi
+.RE
+.SH AUTHOR
+C. Klukas

--- a/doc/json-view.texi
+++ b/doc/json-view.texi
@@ -1,17 +1,25 @@
 \input texinfo
 
 @setfilename json-view.info
-@settitle json-view
+@settitle json-view Manual
 
 @copying
-This document is distributed under the terms of the MIT License.
+This manual is for @code{json-view}, a terminal JSON viewer.
+Copyright (C) 2025 C. Klukas
 @end copying
+
+@dircategory Development
+@direntry
+* json-view: (json-view).  Terminal JSON viewer.
+@end direntry
 
 @titlepage
 @title json-view
-@subtitle A small terminal JSON viewer
-@author John Doe <johndoe@example.com>
-@end titlepage>
+@subtitle Terminal JSON viewer
+@author C. Klukas
+@page
+@insertcopying
+@end titlepage
 
 @contents
 
@@ -24,25 +32,81 @@ This document is distributed under the terms of the MIT License.
 
 @menu
 * Introduction::
-* Invoking json-view::
+* Installation::
+* Usage::
+* Command-line Options::
+* Key Bindings::
 * Concept Index::
 @end menu
 
 @node Introduction
 @chapter Introduction
+@cindex introduction
+@cindex JSON viewer
 
-`json-view` is a small terminal JSON viewer using ncurses. It allows navigating JSON files with arrow keys.
+@code{json-view} displays JSON documents as an interactive tree.  It uses the
+@code{ncurses} library and supports both keyboard and mouse navigation.  Use it
+to quickly explore large documents directly from your terminal.
 
-@node Invoking json-view
-@chapter Invoking json-view
+@node Installation
+@chapter Installation
+@cindex installation
 
-To view a JSON file, pass the path to the file as an argument:
+Building from source requires a C++20 compiler, CMake, the wide-character
+@code{ncursesw} library and @code{nlohmann/json}.  To build and install run:
 
 @example
-json-view path/to/file.json
+cmake -S . -B build
+cmake --build build
+sudo cmake --install build
 @end example
 
-The viewer uses the arrow keys to navigate and `q` to quit.
+The install prefix can be changed by adding
+@code{-DCMAKE_INSTALL_PREFIX=/usr} when configuring CMake.
+
+@node Usage
+@chapter Usage
+@cindex usage
+
+Invoke @code{json-view} with one or more file names:
+
+@example
+json-view example.json another.json
+@end example
+
+If no file is supplied the program reads a single document from standard
+input, making it easy to use in pipelines:
+
+@example
+cat data.json | json-view
+@end example
+
+@node Command-line Options
+@chapter Command-line Options
+@cindex options
+
+@table @code
+@item -h, --help
+Display a short usage summary and exit.
+@item --version
+Show version information and exit.
+@end table
+
+@node Key Bindings
+@chapter Key Bindings
+@cindex key bindings
+@cindex navigation
+@cindex search
+
+@itemize @bullet
+@item @kbd{Up}/@kbd{Down} -- move the selection
+@item @kbd{Left}/@kbd{Right} -- collapse or expand nodes
+@item @kbd{s} -- search keys
+@item @kbd{S} -- search values
+@item @kbd{n}/@kbd{N} -- next/previous search match
+@item @kbd{h} -- show the help screen
+@item @kbd{q} -- quit
+@end itemize
 
 @node Concept Index
 @unnumbered Concept Index


### PR DESCRIPTION
## Summary
- expand README with features, requirements, usage, and key bindings
- flesh out man page with options, key reference, and info manual link
- overhaul Texinfo manual with installation, usage, options, and indexed key bindings

## Testing
- `cmake --build build` *(fails: No rule to make target '/opt/homebrew/opt/ncurses/lib/libncurses.dylib')*
- `makeinfo doc/json-view.texi -o /tmp/json-view.info`
- `man -l doc/json-view.1` *(fails: system minimized; suggests running unminimize)*

------
https://chatgpt.com/codex/tasks/task_e_68bd58e5c6b083309808f6e08ffe54aa