### PR TITLE
Resolve macOS build failures by detecting Homebrew ncurses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y rpm
 
+      - name: Install ncurses
+        if: runner.os == 'macOS'
+        run: brew install ncurses
+
       - name: Configure
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(APPLE)
-  set(CURSES_INCLUDE_PATH "/opt/homebrew/opt/ncurses/include")
-  set(CURSES_LIBRARY "/opt/homebrew/opt/ncurses/lib/libncurses.dylib")
+  find_program(BREW brew)
+  if(BREW)
+    execute_process(
+      COMMAND ${BREW} --prefix ncurses
+      OUTPUT_VARIABLE NCURSES_PREFIX
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    list(APPEND CMAKE_PREFIX_PATH "${NCURSES_PREFIX}")
+  endif()
 endif()
 
 set(CURSES_NEED_WIDE TRUE)


### PR DESCRIPTION
## Summary
- detect Homebrew's ncurses prefix dynamically in CMake
- install ncurses via Homebrew in release workflow

## Testing
- `make`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bd6a724a048330bd563a6208694c95