### PR TITLE
Enable mouse interaction and document --no-mouse flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ useful for quickly inspecting large files directly from the command line.
 * Expand and collapse nodes with the arrow keys or the mouse.
 * Search keys or values and jump between matches.
 * Open multiple files or read JSON from standard input.
-* Optional mouse support for selection and expansion.
+* Mouse interactions: click to select, click left of a label or double-click to expand/collapse, click footer hints, click help dialog to close.
 * `--parse-only` mode for pretty-printing JSON without the interactive viewer.
 
 ## Requirements
@@ -71,12 +71,14 @@ json-view -V
 # or read from standard input
 cat file1.json | json-view
 cat file1.json | json-view --parse-only
+# disable mouse support
+json-view --no-mouse file1.json
 ```
 
 If no file argument is supplied `json-view` will read a single JSON document
 from standard input.  With `--parse-only` the input is formatted and printed to
-standard output. Without it, the interface uses the arrow keys to navigate and
-`q` to quit.
+standard output. Without it, the interface uses the arrow keys (and the mouse)
+to navigate; `--no-mouse` disables mouse handling entirely.
 
 ### Key bindings
 
@@ -92,6 +94,7 @@ standard output. Without it, the interface uses the arrow keys to navigate and
 * `y` – copy selected JSON to clipboard (OSC 52 when supported)
 * `?` – show a help screen
 * `q` – quit the viewer
+* Mouse – click to select, click left of a label or double-click to expand/collapse, click footer hints, click anywhere on the help screen to close it
 
 ## Documentation
 

--- a/doc/json-view.1
+++ b/doc/json-view.1
@@ -19,6 +19,9 @@ Show usage information.
 .TP
 .B -V , --version
 Display version information and exit.
+.TP
+.B --no-mouse
+Disable mouse support and rely on keyboard input only.
 .SH KEYS
 The interface responds to the following keys:
 .TP
@@ -51,6 +54,9 @@ Expand to a specific nesting level (0 collapses all).
 .TP
 .B y
 Copy the selected JSON subtree to the clipboard (via OSC 52 when supported).
+.TP
+.B Mouse
+Click to select rows. Click to the left of a label or double-click to expand or collapse nodes. Click footer hints to trigger their actions and click anywhere on the help screen to close it.
 .TP
 .B ?
 Show the in-application help screen.

--- a/doc/json-view.texi
+++ b/doc/json-view.texi
@@ -90,6 +90,8 @@ cat data.json | json-view
 Display a short usage summary and exit.
 @item -V, --version
 Show version information and exit.
+@item --no-mouse
+Disable mouse support and use only the keyboard.
 @end table
 
 @node Key Bindings
@@ -112,6 +114,7 @@ Show version information and exit.
 @item @kbd{y} -- copy selected JSON to the clipboard (OSC 52 when available)
 @item @kbd{?} -- show the help screen
 @item @kbd{q} -- quit
+@item Mouse -- click to select, click left of a label or double-click to expand/collapse, click footer hints to trigger actions, click anywhere in the help screen to close it
 @end itemize
 
 @node Concept Index


### PR DESCRIPTION
## Summary
- Add optional mouse support: click rows to select, left of label or double-click to toggle, and clickable status-bar hints
- Allow dismissing help dialog with a click and provide `--no-mouse` to disable mouse handling
- Document mouse interactions and new flag in README, man page, and Texinfo manual

## Testing
- `make -j4`
- `./build/json-view --version`


------
https://chatgpt.com/codex/tasks/task_e_68bd6c6e70a483309794305ad3ec56a4