### PR TITLE
Add basic parse-only tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: cmake --build build --config Release --parallel
 
-      - name: Test
+      - name: Run tests
         run: ctest --test-dir build --output-on-failure
 
       - name: Install to staging

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 
 project(json-view VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 
+enable_testing()
+
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -42,6 +44,12 @@ target_include_directories(json-view PRIVATE ${CMAKE_SOURCE_DIR}/include ${CURSE
 target_compile_definitions(json-view PRIVATE JSON_VIEW_VERSION="${PROJECT_VERSION}")
 
 target_link_libraries(json-view PRIVATE ${CURSES_LIBRARIES})
+
+file(GLOB EXAMPLE_JSON_FILES "${CMAKE_SOURCE_DIR}/examples/*.json")
+foreach(json ${EXAMPLE_JSON_FILES})
+  get_filename_component(name ${json} NAME)
+  add_test(NAME parse_${name} COMMAND $<TARGET_FILE:json-view> --parse-only ${json})
+endforeach()
 
 install(TARGETS json-view DESTINATION bin)
 install(FILES doc/json-view.1 DESTINATION share/man/man1)

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ clean:
 run: build
 	./$(BUILD_DIR)/json-view $(ARGS)
 
+test: build
+	ctest --test-dir $(BUILD_DIR) --output-on-failure
+

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ cmake -S . -B build
 cmake --build build
 ```
 
+## Testing
+
+After building, run the parser against the bundled example JSON file:
+
+```sh
+make test
+```
+
 ## Installation
 
 Install the binary (defaults to `/usr/local`):


### PR DESCRIPTION
## Summary
- add CTest for parsing bundled example JSON via `--parse-only`
- expose a `make test` target and document it in README
- run the new tests in the release workflow

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6d52d5848330b61a53f584c56407