### PR TITLE
Link Turbo Vision statically and add Amazon Linux build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,18 @@ jobs:
           cpack -G DEB
           cpack -G RPM
 
+      - name: Build static RPM
+        if: runner.os == 'Linux'
+        run: scripts/build-static-rpm.sh
+
+      - name: Build Amazon Linux 2023 RPM
+        if: runner.os == 'Linux'
+        run: |
+          docker run --rm -v $PWD:/src -w /src amazonlinux:2023 \
+            bash -lc 'dnf install -y cmake gcc gcc-c++ make rpm-build tar && scripts/build-al2023-rpm.sh'
+          VERSION=${GITHUB_REF_NAME#v}
+          mv json-view-${VERSION}-Linux.rpm json-view-${VERSION}-amazonlinux2023.rpm
+
       - name: Upload release assets
         uses: softprops/action-gh-release@v1
         with:
@@ -61,5 +73,7 @@ jobs:
             json-view-*.tar.gz
             build/*.deb
             build/*.rpm
+            json-view-static-*.rpm
+            json-view-*amazonlinux2023*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,26 @@ if(NOT CURSES_FOUND)
   message(FATAL_ERROR "Could not find ncurses; install ncurses or set CMAKE_PREFIX_PATH")
 endif()
 
+# When building static binaries we prefer linking against the static variant of
+# ncurses to avoid hard dependencies on the system's libncursesw. Override the
+# library list returned by FindCurses with plain library names so the linker
+# can pick the `.a` files.
+option(JSON_VIEW_STATIC "Link json-view binaries statically" OFF)
+if(JSON_VIEW_STATIC)
+  # Resolve static ncurses libraries explicitly to avoid pulling in the
+  # dynamic versions via linker scripts.
+  set(_orig_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+  find_library(NCURSESW_LIB ncursesw REQUIRED)
+  find_library(FORMW_LIB formw REQUIRED)
+  find_library(TINFO_LIB tinfo REQUIRED)
+  set(CURSES_LIBRARIES ${NCURSESW_LIB} ${FORMW_LIB} ${TINFO_LIB})
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${_orig_suffixes})
+endif()
+
+# Option to build the Turbo Vision based frontend.
+option(BUILD_JSON_VIEW_APP "Build Turbo Vision based json-view-app" ON)
+
 add_executable(json-view src/json-view.cpp)
 add_library(json_view_core STATIC src/json_view_core.cpp)
 target_include_directories(json_view_core PUBLIC ${CMAKE_SOURCE_DIR}/include)
@@ -55,21 +75,48 @@ target_compile_definitions(json-view PRIVATE JSON_VIEW_VERSION="${PROJECT_VERSIO
 
 target_link_libraries(json-view PRIVATE json_view_core ${CURSES_LIBRARIES})
 
-# Fetch Turbo Vision for the alternate frontend
-include(FetchContent)
-set(TV_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-set(TV_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-FetchContent_Declare(
-  tvision
-  GIT_REPOSITORY https://github.com/magiblot/tvision.git
-  GIT_TAG 7ecc590ac59b163a876da50867c69bba605cebfc
-)
-FetchContent_MakeAvailable(tvision)
+# Fetch Turbo Vision for the alternate frontend if enabled
+if(BUILD_JSON_VIEW_APP)
+  include(FetchContent)
+  set(tv_cmake_args -DTV_BUILD_EXAMPLES=OFF -DTV_BUILD_TESTS=OFF)
+  if(JSON_VIEW_STATIC)
+    list(APPEND tv_cmake_args -DTV_BUILD_USING_GPM=OFF -DCMAKE_FIND_LIBRARY_SUFFIXES=.a)
+  endif()
+  FetchContent_Declare(
+    tvision
+    GIT_REPOSITORY https://github.com/magiblot/tvision.git
+    GIT_TAG 7ecc590ac59b163a876da50867c69bba605cebfc
+    CMAKE_ARGS ${tv_cmake_args}
+  )
+  FetchContent_MakeAvailable(tvision)
 
-add_executable(json-view-app src/json-view-app.cpp)
-target_include_directories(json-view-app PRIVATE ${CMAKE_SOURCE_DIR}/include)
-target_compile_definitions(json-view-app PRIVATE JSON_VIEW_VERSION="${PROJECT_VERSION}")
-target_link_libraries(json-view-app PRIVATE json_view_core tvision::tvision)
+  if(JSON_VIEW_STATIC)
+    # Replace tvision's ncurses and tinfo dependencies with explicit static
+    # libraries resolved above.
+    get_target_property(_tv_libs tvision INTERFACE_LINK_LIBRARIES)
+    if(_tv_libs)
+      list(FILTER _tv_libs EXCLUDE REGEX "ncursesw|tinfo")
+    endif()
+    list(APPEND _tv_libs ${NCURSESW_LIB} ${FORMW_LIB} ${TINFO_LIB})
+    set_target_properties(tvision PROPERTIES INTERFACE_LINK_LIBRARIES "${_tv_libs}")
+  endif()
+
+  add_executable(json-view-app src/json-view-app.cpp)
+  target_include_directories(json-view-app PRIVATE ${CMAKE_SOURCE_DIR}/include)
+  target_compile_definitions(json-view-app PRIVATE JSON_VIEW_VERSION="${PROJECT_VERSION}")
+  target_link_libraries(json-view-app PRIVATE json_view_core tvision::tvision ${CURSES_LIBRARIES})
+endif()
+
+# Optionally build fully static binaries to avoid runtime dependencies on
+# specific versions of glibc or ncurses. This is useful when targeting
+# platforms like Amazon Linux 2023 whose system libraries may be older than
+# those used to build the package. Enable with `-DJSON_VIEW_STATIC=ON`.
+if(JSON_VIEW_STATIC)
+  target_link_options(json-view PRIVATE -static -static-libgcc -static-libstdc++)
+  if(TARGET json-view-app)
+    target_link_options(json-view-app PRIVATE -static -static-libgcc -static-libstdc++)
+  endif()
+endif()
 
 file(GLOB EXAMPLE_JSON_FILES "${CMAKE_SOURCE_DIR}/examples/*.json")
 foreach(json ${EXAMPLE_JSON_FILES})
@@ -83,7 +130,9 @@ foreach(json ${EXAMPLE_JSON_FILES})
 endforeach()
 
 install(TARGETS json-view RUNTIME DESTINATION bin)
-install(TARGETS json-view-app RUNTIME DESTINATION bin)
+if(TARGET json-view-app)
+  install(TARGETS json-view-app RUNTIME DESTINATION bin)
+endif()
 install(TARGETS json_view_core ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
 configure_file(doc/json-view.1.in ${CMAKE_CURRENT_BINARY_DIR}/doc/json-view.1 @ONLY)
 configure_file(doc/json-view.texi.in ${CMAKE_CURRENT_BINARY_DIR}/doc/json-view.texi @ONLY)
@@ -101,4 +150,12 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS "libncursesw5 (>= 6.2) | libncurses6, libtvisio
 set(CPACK_RPM_PACKAGE_REQUIRES "ncurses, tvision")
 set(CPACK_RPM_PACKAGE_LICENSE "GPL-3.0-or-later")
 set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
+
+if(JSON_VIEW_STATIC)
+  # Static builds do not require ncurses or tvision at runtime and are
+  # distributed under a separate package name to avoid confusion with the
+  # dynamically linked RPM.
+  set(CPACK_PACKAGE_NAME "json-view-static")
+  set(CPACK_RPM_PACKAGE_REQUIRES "")
+endif()
 include(CPack)

--- a/README.md
+++ b/README.md
@@ -132,9 +132,34 @@ The install prefix can be changed at configure time using
 Tagged releases on GitHub provide pre-built packages:
 
 * Linux `.deb` and `.rpm`
+* Amazon Linux 2023 `.rpm`
+* Fully static `json-view-static` `.rpm`
 * `.tar.gz` archives for Linux and macOS containing `json-view`, docs, and an `install.sh` helper
 
 Download them from the repository's Releases page.
+
+### Amazon Linux 2023
+
+The standard RPM is built on newer Linux distributions and may fail to install
+on Amazon Linux 2023. A package built against the libraries bundled with that
+distribution is provided in the releases. To recreate it locally run:
+
+```sh
+scripts/build-al2023-rpm.sh
+```
+
+This generates a package equivalent to the default release but linked against
+the system-provided libraries.
+
+If a completely self-contained package is preferred, you can build a fully
+static variant instead:
+
+```sh
+scripts/build-static-rpm.sh
+```
+
+This produces a `json-view-static` RPM containing both `json-view` and
+`json-view-app` with no runtime library dependencies.
 
 ## Usage
 

--- a/scripts/build-al2023-rpm.sh
+++ b/scripts/build-al2023-rpm.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Build an RPM of json-view using the system libraries on Amazon Linux 2023.
+# Run this script on an Amazon Linux 2023 environment (e.g., in CI) to produce
+# a package linked against the distribution's glibc and ncurses versions.
+# Usage: scripts/build-al2023-rpm.sh [build-dir]
+
+BUILD_DIR=${1:-build-al2023}
+
+cmake -S . -B "$BUILD_DIR"
+cmake --build "$BUILD_DIR"
+# Generate the RPM using CPack
+cpack -G RPM --config "$BUILD_DIR/CPackConfig.cmake"

--- a/scripts/build-static-rpm.sh
+++ b/scripts/build-static-rpm.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Build a statically linked RPM of json-view. This avoids runtime
+# dependencies on the host's glibc or ncurses libraries and is suitable for
+# platforms like Amazon Linux 2023 whose system libraries are older than
+# the ones used to build the standard package.
+# Usage: scripts/build-static-rpm.sh [build-dir]
+
+BUILD_DIR=${1:-build-static}
+
+cmake -S . -B "$BUILD_DIR" -DJSON_VIEW_STATIC=ON
+cmake --build "$BUILD_DIR"
+# Generate the RPM using CPack
+cpack -G RPM --config "$BUILD_DIR/CPackConfig.cmake"


### PR DESCRIPTION
## Summary
- link Turbo Vision frontend statically so feature parity is maintained across builds
- add `build-al2023-rpm.sh` to create an RPM on Amazon Linux using system libraries
- include Turbo Vision in `build-static-rpm.sh` for a fully static `json-view`/`json-view-app` package
- update release workflow to publish static and Amazon Linux RPMs
- document availability of these packages in releases

## Testing
- `make`
- `make test`
- `scripts/build-static-rpm.sh`
- `scripts/build-al2023-rpm.sh`


------
https://chatgpt.com/codex/tasks/task_e_68be823392d483309daaba8c4f16bd2a