### PR TITLE
Fix ncurses header path for tvision on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,13 @@ if(BUILD_JSON_VIEW_APP)
   )
   FetchContent_MakeAvailable(tvision)
 
+  # Ensure tvision uses the normalized ncurses include path on macOS.
+  # tvision::tvision is an ALIAS target, so modify the actual "tvision"
+  # target to avoid CMake's ALIAS restrictions.
+  if(APPLE AND TARGET tvision)
+    target_include_directories(tvision SYSTEM BEFORE PUBLIC ${CURSES_INCLUDE_DIRS})
+  endif()
+
   add_executable(json-view-app src/json-view-app.cpp)
   target_include_directories(json-view-app PRIVATE ${CMAKE_SOURCE_DIR}/include)
   target_compile_definitions(json-view-app PRIVATE JSON_VIEW_VERSION="${PROJECT_VERSION}")


### PR DESCRIPTION
## Summary
- ensure tvision uses normalized ncurses include path on macOS

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bee771a6bc8330bd51ae114480e315